### PR TITLE
Make the ifconfig string check more portable

### DIFF
--- a/run/root/getvpnip.sh
+++ b/run/root/getvpnip.sh
@@ -26,7 +26,7 @@ fi
 vpn_ip=""
 while ! check_valid_ip "${vpn_ip}"; do
 
-	vpn_ip=$(ifconfig "${VPN_DEVICE_TYPE}" 2>/dev/null | grep 'inet' | grep -P -o -m 1 '(?<=inet\s)[^\s]+')
+	vpn_ip=$(ifconfig "${VPN_DEVICE_TYPE}" 2>/dev/null | grep -P -o -m 1 '(?<=inet\s)[^\s]+' | sed 's/addr://')
 	sleep 1s
 
 done


### PR DESCRIPTION
The output of ifconfig is not consistent across linux flavours. This change makes the grepping of the IP address more portable.