### PR TITLE
Catch whitespaces in wg0.conf

### DIFF
--- a/run/root/wireguard.sh
+++ b/run/root/wireguard.sh
@@ -177,10 +177,10 @@ function edit_wireguard() {
 	sed -i -e "/\[Interface\]/a PostUp = '/root/wireguardup.sh'\nPostDown = '/root/wireguarddown.sh'" "${VPN_CONFIG}"
 
 	# removes all ipv6 address and port from wireguard config
-	sed -r -i -e 's/,?[a-f0-9]{4}::?[^,]+,?//g' "${VPN_CONFIG}"
+	sed -r -i -e 's/,? ?[a-f0-9]{4}::?[^,]+,?//g' "${VPN_CONFIG}"
 
 	# removes all ipv6 port only from wireguard config
-	sed -r -i -e 's/,?::[^,]+,?//g' "${VPN_CONFIG}"
+	sed -r -i -e 's/,? ?::[^,]+,?//g' "${VPN_CONFIG}"
 
 }
 


### PR DESCRIPTION
Many VPN providers supply wireguard configs with whitespaces in their configs. This change will catch those whitespaces