### PR TITLE
added feature flag VPN_AIRVPN_DNS to set DNS server for AIRVPN users …

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -374,6 +374,15 @@ if [[ "${VPN_ENABLED}" == "yes" ]]; then
 		fi
 	fi
 
+	if [[ "${VPN_AIRVPN_DNS}" == "true" ]]; then
+		if [[ ! -z "${VPN_AIRVPN_DNS}" ]]; then
+			echo "[info] VPN_AIRVPN_DNS defined as '${VPN_AIRVPN_DNS}'" | ts '%Y-%m-%d %H:%M:%.S'
+			export VPN_AIRVPN_DNS=$(echo "${VPN_AIRVPN_DNS}")
+		else
+			echo "[info] VPN_AIRVPN_DNS not set, set to true if airvpn dns is to be used" | ts '%Y-%m-%d %H:%M:%.S'
+		fi
+	fi	
+
 	if [[ "${VPN_PROV}" == "pia" ]]; then
 
 		export STRICT_PORT_FORWARD=$(echo "${STRICT_PORT_FORWARD}" | sed -e 's~^[ \t]*~~;s~[ \t]*$~~')

--- a/run/root/getvpnextip.sh
+++ b/run/root/getvpnextip.sh
@@ -102,6 +102,12 @@ if [[ "${APPLICATION}" != "sabnzbd" ]] && [[ "${APPLICATION}" != "privoxy" ]]; t
 		return 1
 
 	else
+		
+		if [[ "${VPN_AIRVPN_DNS}" == "true" ]]; then
+			ext_ip=$(cat /tmp/getvpnextip)
+			echo "[info] Set nameserver to $ext_ip"
+			echo "nameserver $ext_ip" > /etc/resolv.conf
+		fi
 
 		echo "[info] Successfully retrieved external IP address ${result}"
 		return 0

--- a/run/root/openvpn.sh
+++ b/run/root/openvpn.sh
@@ -19,6 +19,13 @@ function create_openvpn_cli() {
 
 	fi
 
+	if [[ "${VPN_AIRVPN_DNS}" == "true" ]]; then
+
+		# add airvpndns flag
+		openvpn_cli="${openvpn_cli} --setenv VPN_AIRVPN_DNS '${VPN_AIRVPN_DNS}'"
+
+	fi
+
 	if [[ ! -z "${VPN_USER}" && ! -z "${VPN_PASS}" ]]; then
 
 		# add additional flags to pass credentials


### PR DESCRIPTION
This PR introduces an environment variable that can be used by AIRVPN users to change their DNS without the need to know the IP beforehand.

If VPN_AIRVPN_DNS is set to true, the docker container will use the exit IP of AIRVPN as the nameserver. 

Airvpn encourages to use of DNS push (https://airvpn.org/specs/). I am not too familiar with OVPN and this workaround may be unnecessary.

This PR is linked to this issue https://github.com/binhex/arch-delugevpn/issues/298. I only later figured out that the base image would need to be changed.