### PR TITLE
identify docker interface more reliably

### DIFF
--- a/run/root/iptable.sh
+++ b/run/root/iptable.sh
@@ -45,7 +45,7 @@ if [[ ! -z "${VPN_OUTPUT_PORTS}" ]]; then
 fi
 
 # identify docker bridge interface name by looking at defult route
-docker_interface=$(ip -4 route ls | grep default | xargs | grep -o -P '[^\s]+$')
+docker_interface=$(ip -4 route ls | grep default | xargs | grep -o -P '(?<=dev )([^\s]+)')
 if [[ "${DEBUG}" == "true" ]]; then
 	echo "[debug] Docker interface defined as ${docker_interface}"
 fi


### PR DESCRIPTION
I tried setting up an arch-delugevpn container with podman and docker-compose and it wouldn't work.
So i looked at the logs and saw, that the identified interface was `100` which didn't seem right.

The code executes `ip -4 route ls` and just looks at the last word and uses that as the interface.
But in my container the output of ip route looks like this: 
```
default via 10.88.0.1 dev eth0 proto static metric 100 
10.88.0.0/16 dev eth0 proto kernel scope link src 10.88.0.10
```
so it thought my interface was `100` which it isn't. 

Instead of checking for the last word, i wrote a regex that checks for the word after `dev `. 
I'm not 100% sure if that's the right way of doing it, as I'm not that experienced, but in my experiments it worked that way.