### PR TITLE
Restrict access to wg0.conf

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -165,6 +165,16 @@ if [[ "${VPN_ENABLED}" == "yes" ]]; then
 			fi
 			echo "[info] WireGuard config file (conf extension) is located at ${VPN_CONFIG}" | ts '%Y-%m-%d %H:%M:%.S'
 
+			# restrict access to wireguard config file
+			set +e
+			chmod 600 "${VPN_CONFIG}" &> /dev/null
+			exit_code_chmod=$?
+			set -e
+
+			if (( ${exit_code_chmod} != 0 )); then
+				echo "[warn] Unable to chmod ${VPN_CONFIG}, assuming SMB mountpoint" | ts '%Y-%m-%d %H:%M:%.S'
+			fi
+
 			# convert CRLF (windows) to LF (unix) for wireguard conf file
 			/usr/local/bin/dos2unix.sh "${VPN_CONFIG}"
 


### PR DESCRIPTION
Fixes a warning from wg-quick about world access on wg0.conf by restricting permissions to rw for the owner.

I don't know why the permissions are recursively set to 755 on /config/wireguard a bit further up in install.sh, but that affects wg0.conf as well, so I just fix the permissions specifically for that file after is has been located.