### PR TITLE
Disable logging

### DIFF
--- a/run/nobody/microsocks.sh
+++ b/run/nobody/microsocks.sh
@@ -12,6 +12,10 @@ if [[ "${VPN_ENABLED}" == "yes" ]]; then
 	microsocks_cli="${microsocks_cli} -b ${vpn_ip}"
 fi
 
+if [[ "${DEBUG}" == "false" ]]; then
+	microsocks_cli="${microsocks_cli} -q"
+fi
+
 ${microsocks_cli} &
 
 echo "[info] microsocks process started"


### PR DESCRIPTION
In the privoxyvpn container DEBUG=false is supposed to disable any logging. Microsocks however still outputs all outgoing connections. This should stop that.